### PR TITLE
Add brew_token and api_host to run_action

### DIFF
--- a/app/addon_cmds/commands.py
+++ b/app/addon_cmds/commands.py
@@ -197,5 +197,7 @@ def uninstall(ctx):
         addons=ctx.obj["addons_dict"],
         parallel=ctx.obj["parallel"],
         timeout=ctx.obj["timeout"],
+        brew_token=ctx.obj["brew_token"],
+        api_host=ctx.obj["api_host"],
         rosa=ctx.obj["rosa"],
     )


### PR DESCRIPTION
Flags `brew-token` and `api-host` are set with defaults/not required for cli, but expected in `run_action` function.

Therefore, both arguments are missing in the `uninstall` function and causes failures.