### PR TITLE
Require poetry to use version higher than 1.0.21 for openshift-cluster-management-python-wrapper

### DIFF
--- a/app/addon_cmds/commands.py
+++ b/app/addon_cmds/commands.py
@@ -9,23 +9,13 @@ from utils import extract_operator_addon_params
 
 
 def run_action(
-    action,
-    addons,
-    parallel,
-    timeout,
-    rosa,
-    brew_token=None,
-    api_host="stage",
+    action, addons, parallel, timeout, rosa, brew_token=None, api_host="stage"
 ):
     jobs = []
     for values in addons.values():
         cluster_addon_obj = values["cluster_addon"]
         addon_action_func = getattr(cluster_addon_obj, action)
-        kwargs = {
-            "wait": True,
-            "wait_timeout": timeout,
-            "rosa": rosa,
-        }
+        kwargs = {"wait": True, "wait_timeout": timeout, "rosa": rosa}
         if action == "install_addon":
             kwargs["parameters"] = values["parameters"]
             if cluster_addon_obj.addon_name == "managed-odh" and api_host == "stage":

--- a/app/addon_cmds/commands.py
+++ b/app/addon_cmds/commands.py
@@ -9,13 +9,23 @@ from utils import extract_operator_addon_params
 
 
 def run_action(
-    action, addons, parallel, timeout, rosa, brew_token=None, api_host="stage"
+    action,
+    addons,
+    parallel,
+    timeout,
+    rosa,
+    brew_token=None,
+    api_host="stage",
 ):
     jobs = []
     for values in addons.values():
         cluster_addon_obj = values["cluster_addon"]
         addon_action_func = getattr(cluster_addon_obj, action)
-        kwargs = {"wait": True, "wait_timeout": timeout, "rosa": rosa}
+        kwargs = {
+            "wait": True,
+            "wait_timeout": timeout,
+            "rosa": rosa,
+        }
         if action == "install_addon":
             kwargs["parameters"] = values["parameters"]
             if cluster_addon_obj.addon_name == "managed-odh" and api_host == "stage":

--- a/poetry.lock
+++ b/poetry.lock
@@ -2446,4 +2446,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "cafaa6968dd1ae85dce0baf90980c74fc866c7639d27c422c40e3898ec1de93c"
+content-hash = "a5d0414df280dd026ccf541c3396cbb3b2bc11db238da835f7b4f97b1a39e079"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = "^3.8"
 colorlog = "*"
 openshift-python-wrapper = "*"
 openshift-python-utilities = "*"
-openshift-cluster-management-python-wrapper = "*"
+openshift-cluster-management-python-wrapper = "^1.0.20"
 click = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python = "^3.8"
 colorlog = "*"
 openshift-python-wrapper = "*"
 openshift-python-utilities = "*"
-openshift-cluster-management-python-wrapper = "^1.0.20"
+openshift-cluster-management-python-wrapper = "^1.0.21"
 click = "*"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Requiring that `openshift-cluster-management-python-wrapper` version is higher than `1.0.20` - 
Current release is `v1.0.21`