### PR TITLE
Update rosa-python-client to v1.0.10

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2052,14 +2052,14 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rosa-python-client"
-version = "1.0.8"
+version = "1.0.10"
 description = "Wrapper for rosa cli"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "rosa_python_client-1.0.8-py3-none-any.whl", hash = "sha256:e1e18b3fb1dc99ac58eb7b62513b4834c89b58cb21527532decbe1fac0c82df1"},
-    {file = "rosa_python_client-1.0.8.tar.gz", hash = "sha256:dc07c4c7f8571cdc4e70475ff225147e2345e26055b5c1c4a2418dc1d9a6cbe0"},
+    {file = "rosa_python_client-1.0.10-py3-none-any.whl", hash = "sha256:60bd1f0a5371ada4db0337690e67508dc52d3dc09e16864838ff5de5f8ec49fc"},
+    {file = "rosa_python_client-1.0.10.tar.gz", hash = "sha256:1fa843b649c65d3f61414560036a275d85072437b7a4b7ee8985cbbfa8dda977"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Can we set the bot to auto-update dependency for `rosa-python-client`?