### PR TITLE
Fix target namespaces value get

### DIFF
--- a/app/operator_cmds/commands.py
+++ b/app/operator_cmds/commands.py
@@ -1,7 +1,7 @@
+import ast
 import multiprocessing
 import os
 
-import ast
 import click
 from click_dict_type import DictParamType
 from constants import TIMEOUT_30MIN
@@ -35,7 +35,9 @@ def run_action(client, action, operators_tuple, parallel, brew_token=None):
             kwargs["channel"] = _operator.get("channel", "stable")
             kwargs["source"] = _operator.get("source", "redhat-operators")
             kwargs["iib_index_image"] = _operator.get("iib")
-            kwargs["target_namespaces"] = ast.literal_eval(_operator.get("target_namespaces"))
+            kwargs["target_namespaces"] = ast.literal_eval(
+                _operator.get("target_namespaces")
+            )
 
         if parallel:
             job = multiprocessing.Process(

--- a/app/operator_cmds/commands.py
+++ b/app/operator_cmds/commands.py
@@ -34,7 +34,7 @@ def run_action(client, action, operators_tuple, parallel, brew_token=None):
             kwargs["channel"] = _operator.get("channel", "stable")
             kwargs["source"] = _operator.get("source", "redhat-operators")
             kwargs["iib_index_image"] = _operator.get("iib")
-            kwargs["target_namespaces"] = _operator.get("target-namespaces")
+            kwargs["target_namespaces"] = _operator.get("target_namespaces")
 
         if parallel:
             job = multiprocessing.Process(

--- a/app/operator_cmds/commands.py
+++ b/app/operator_cmds/commands.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import os
 
+import ast
 import click
 from click_dict_type import DictParamType
 from constants import TIMEOUT_30MIN
@@ -34,7 +35,7 @@ def run_action(client, action, operators_tuple, parallel, brew_token=None):
             kwargs["channel"] = _operator.get("channel", "stable")
             kwargs["source"] = _operator.get("source", "redhat-operators")
             kwargs["iib_index_image"] = _operator.get("iib")
-            kwargs["target_namespaces"] = _operator.get("target_namespaces")
+            kwargs["target_namespaces"] = ast.literal_eval(_operator.get("target_namespaces"))
 
         if parallel:
             job = multiprocessing.Process(


### PR DESCRIPTION
- `target-namespaces` --> `target_namespaces` fixed
- list of target namespaces value within _operator passed as str; using `ast.literal_eval` to restore it to list