### PR TITLE
Fix cluster_name for must-gather dest-dir option

### DIFF
--- a/ocp_addons_operators_cli/utils/operators_utils.py
+++ b/ocp_addons_operators_cli/utils/operators_utils.py
@@ -84,7 +84,7 @@ def get_cluster_name_from_kubeconfig(kubeconfig, operator_name):
         LOGGER.error(f"Operator: {operator_name} kubeconfig file contains more than one cluster.")
         raise click.Abort()
 
-    return kubeconfig_clusters[0]["name"]
+    return kubeconfig_clusters[0]["name"].split(":")[0]
 
 
 def get_operator_iib_from_iib_dict(iib_dict, operator_dict, job_name=None):


### PR DESCRIPTION
Fix `cluster_name` extracted from kubeconfig.

must-gather failed with error: `--dest-dir may not contain special characters such as colon(:)` for cluster name `api-ci-rosa-s-8ncb-lx8l-s1-devshift-org:6443`

Logs of failed job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-release-tests-release-v1.15-openshift-pipelines-p2p-rosa-classic-openshift-pipelines-serverless-rosa-classic-416-iib/1820514887781060608/artifacts/openshift-pipelines-serverless-rosa-classic-416-iib/operator-install/build-log.txt