### PR TITLE
[WIP] update file persmissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/bin/
 ENV PATH="/ocp-addons-operators-cli/bin:$PATH"
 
 RUN uv sync
+RUN chgrp -R 0 ${APP_DIR}/.cache && \
+    chmod -R g=u ${APP_DIR}/.cache
 
 ENTRYPOINT ["uv", "run", "ocp_addons_operators_cli/cli.py"]


### PR DESCRIPTION
When running as non root user (Openshift-Ci env), any uv execution command such as
```
uv run ocp_addons_operators_cli/cli.py --help
```

Hits the following permission error:

```
error: failed to open file `/.cache/sdists-v8/.git`: Permission denied (os error 13)
```